### PR TITLE
Bug/new section definition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    plate_api (1.1.2)
+    plate_api (1.1.3)
       faraday (~> 0.15.4)
       faraday_middleware (~> 0.13.1)
       mimemagic (~> 0.3.3)
@@ -36,7 +36,7 @@ GEM
     json (2.1.0)
     mimemagic (0.3.3)
     minitest (5.11.3)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     public_suffix (3.0.3)
     rake (10.5.0)
     rspec (3.8.0)

--- a/lib/plate_api/plate_object/base.rb
+++ b/lib/plate_api/plate_object/base.rb
@@ -73,8 +73,9 @@ module PlateApi::PlateObject
     end
 
     def self.has_one(name, klass)
+      HasOneRelations[self.name] ||= {}
       self.attr_accessor "#{name}_id"
-      HasOneRelations[name.to_s] = klass
+      HasOneRelations[self.name][name.to_s] = klass
       define_has_one_method(name, klass)
     end
 
@@ -87,7 +88,8 @@ module PlateApi::PlateObject
     end
 
     def self.has_many(plural_name, singular_name, klass, define_create_method=false)
-      HasManyRelations[plural_name.to_s] = klass
+      HasManyRelations[self.name] ||= {}
+      HasManyRelations[self.name][plural_name.to_s] = klass
       define_has_many_methods(plural_name, klass)
       define_create_method(singular_name, klass) if define_create_method
     end
@@ -113,8 +115,10 @@ module PlateApi::PlateObject
     end
 
     def set_relation_ids(relations_attributes)
+      HasOneRelations[self.class.name] ||= {}
+
       return unless relations_attributes
-      self.class::HasOneRelations.keys.each do |relation_name|
+      self.class::HasOneRelations[self.class.name].keys.each do |relation_name|
         val = relations_attributes["#{relation_name}_id"]
         if val
           send("#{relation_name}_id=", val)

--- a/lib/plate_api/plate_object/section.rb
+++ b/lib/plate_api/plate_object/section.rb
@@ -2,6 +2,7 @@ module PlateApi::PlateObject
   class Section < Base
 
     has_one :post, "PlateApi::PlateObject::Post"
+    has_one :site_translation, "PlateApi::PlateObject::SiteTranslation"
     has_many :rows, :row, "PlateApi::PlateObject::Row", true
     has_many :columns, :column, "PlateApi::PlateObject::Column"
     has_many :elements, :element, "PlateApi::PlateObject::Element"

--- a/lib/plate_api/version.rb
+++ b/lib/plate_api/version.rb
@@ -1,3 +1,3 @@
 module PlateApi
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end


### PR DESCRIPTION
Fixed the bug where relations ids returned by the Plate API were not selected as has_one or has_many relations, but the relations ids were valid has_one or has_many relations for different classes.
