### PR TITLE
raise error, add specs

### DIFF
--- a/lib/plate_api.rb
+++ b/lib/plate_api.rb
@@ -9,6 +9,7 @@ require "plate_api/delete_request"
 require "plate_api/post_request"
 require "plate_api/post_multipart_request"
 require "plate_api/put_request"
+require "plate_api/errors"
 
 
 module PlateApi

--- a/lib/plate_api/errors.rb
+++ b/lib/plate_api/errors.rb
@@ -1,0 +1,5 @@
+module Errors
+  class ApiError < StandardError
+
+  end
+end

--- a/lib/plate_api/object_handler.rb
+++ b/lib/plate_api/object_handler.rb
@@ -18,7 +18,7 @@ module PlateApi
         return new_object(result["data"])
       else
         puts "PlateApi: No success: #{result}"
-        return nil
+        raise Errors::ApiError.new(result)
       end
     end
 
@@ -31,7 +31,7 @@ module PlateApi
         return new_object(result["data"])
       else
         puts "PlateApi: No success: #{result}"
-        return nil
+        raise Errors::ApiError.new(result)
       end
     end
 
@@ -51,7 +51,7 @@ module PlateApi
         return new_object(result["data"])
       else
         puts "PlateApi: No success: #{result}"
-        return nil
+        raise Errors::ApiError.new(result)
       end
     end
 
@@ -62,7 +62,7 @@ module PlateApi
         return new_object(result["data"])
       else
         puts "PlateApi: No success: #{result}"
-        return nil
+        raise Errors::ApiError.new(result)
       end
     end
 
@@ -75,7 +75,7 @@ module PlateApi
         return result["data"].map{|x| new_object(x)}
       else
         puts "PlateApi: No success: #{result}"
-        return nil
+        raise Errors::ApiError.new(result)
       end
     end
 
@@ -85,7 +85,7 @@ module PlateApi
         return result["meta"]["pagination"]["total_records"]
       else
         puts "PlateApi: No success: #{result}"
-        return nil
+        raise Errors::ApiError.new(result)
       end
     end
 

--- a/spec/classes/object_handler_spec.rb
+++ b/spec/classes/object_handler_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PlateApi::ObjectHandler do
         end
 
         it "returns nil" do
-          expect(subject.find(5)).to be_nil
+          expect{subject.find(5)}.to raise_error Errors::ApiError
         end
 
       end
@@ -114,7 +114,7 @@ RSpec.describe PlateApi::ObjectHandler do
           end
 
           it "returns nil" do
-            expect(subject.update(5, {"name" => nil})).to be_nil
+            expect{subject.update(5, {"name" => nil})}.to raise_error Errors::ApiError
           end
         end
       end
@@ -128,7 +128,7 @@ RSpec.describe PlateApi::ObjectHandler do
         end
 
         it "returns nil" do
-          expect(subject.update(5, {"name" => "A New Name"})).to be_nil
+          expect{subject.update(5, {"name" => "A New Name"})}.to raise_error
         end
 
       end
@@ -159,7 +159,7 @@ RSpec.describe PlateApi::ObjectHandler do
         end
 
         it "returns nil" do
-          expect(subject.delete(5)).to be_nil
+          expect{subject.delete(5)}.to raise_error Errors::ApiError
         end
 
       end


### PR DESCRIPTION
to be able to read an erroneous response, we need to return something meaningful.

So, in case I want to create an attachment for a site, I need to use `PlateApi.new(skey, pkey).sites.create_attachment(attachment)`, but if for some reason the PlateApi doesn't have an activated API integration, or an incorrectly filled authorisations table, there's no way to find out because the response is nil.

